### PR TITLE
Ignore idea files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Thumbs.db
 
 # Ignore built ts files
 dist/**/*
+
+# Ignore idea bullshit
+.idea


### PR DESCRIPTION
В `.gitignore`Добавлен игнор папки `.idea`, используемой программными продуктами компании JetBrains для настроек проекта